### PR TITLE
Update wrapper to work with ssw-py >= 1.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ License: MIT + file LICENSE
 URL: https://nanx.me/ssw-r/, https://github.com/nanxstats/ssw-r
 BugReports: https://github.com/nanxstats/ssw-r/issues
 Encoding: UTF-8
-SystemRequirements: Python (>= 3.6.0), ssw-py (>= 0.2.6).
+SystemRequirements: Python (>= 3.6.0), ssw-py (>= 1.0.0).
     Detailed installation instructions can be found in the README file.
 VignetteBuilder: knitr
 Depends: R (>= 4.1.0)
@@ -21,4 +21,5 @@ Imports:
 Suggests:
     knitr,
     rmarkdown
+Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/R/align.R
+++ b/R/align.R
@@ -19,18 +19,27 @@
 #' a
 #' a$alignment$optimal_score
 #' a$alignment$sub_optimal_score
-align <- function(read = NULL, reference = NULL, gap_open = 3L, gap_extension = 1L, start_idx = 0L, end_idx = 0L, match_score = 2L, mismatch_penalty = 2L) {
-  if (is.null(read) | is.null(reference)) stop("read and reference cannot be NULL")
-  obj <- ssw_py$SSW(match_score = as.integer(match_score), mismatch_penalty = as.integer(mismatch_penalty))
-  obj$setRead(read)
-  obj$setReference(reference)
+align <- function(
+    read,
+    reference,
+    gap_open = 3L,
+    gap_extension = 1L,
+    start_idx = 0L,
+    end_idx = 0L,
+    match_score = 2L,
+    mismatch_penalty = 2L) {
+  obj <- ssw_py$AlignmentMgr(
+    match_score = as.integer(match_score),
+    mismatch_penalty = as.integer(mismatch_penalty)
+  )
+  obj$set_read(read)
+  obj$set_reference(reference)
   res <- obj$align(
     gap_open = as.integer(gap_open),
     gap_extension = as.integer(gap_extension),
     start_idx = as.integer(start_idx),
     end_idx = as.integer(end_idx)
   )
-  lst <- list("ssw" = obj, "alignment" = res)
-  class(lst) <- "ssw"
-  lst
+
+  structure(list("ssw" = obj, "alignment" = res), class = "ssw")
 }

--- a/R/force_align.R
+++ b/R/force_align.R
@@ -22,13 +22,31 @@
 #'
 #' # Print the formatted results directly
 #' a |> formatter(print = TRUE)
+force_align <- function(
+    read,
+    reference,
+    force_overhang = FALSE,
+    match_score = 2L,
+    mismatch_penalty = 2L) {
+  obj <- ssw_py$AlignmentMgr(
+    match_score = as.integer(match_score),
+    mismatch_penalty = as.integer(mismatch_penalty)
+  )
+  obj$set_read(read)
+  obj$set_reference(reference)
+  res <- ssw_py$force_align(
+    read = read,
+    reference = reference,
+    force_overhang = force_overhang
+  )
 
-force_align <- function(read, reference, force_overhang = FALSE, match_score = 2L, mismatch_penalty = 2L) {
-  obj <- ssw_py$SSW(match_score = as.integer(match_score), mismatch_penalty = as.integer(mismatch_penalty))
-  obj$setRead(read)
-  obj$setReference(reference)
-  res <- ssw_py$force_align(read = read, reference = reference, force_overhang = force_overhang)
-  lst <- list("ssw" = obj, "alignment" = res, "read" = read, "reference" = reference)
-  class(lst) <- "ssw"
-  lst
+  structure(
+    list(
+      "ssw" = obj,
+      "alignment" = res,
+      "read" = read,
+      "reference" = reference
+    ),
+    class = "ssw"
+  )
 }

--- a/R/package.R
+++ b/R/package.R
@@ -6,7 +6,7 @@
 
 #' Global reference to ssw-py
 #'
-#' Global reference to ssw-py which will be initialized in \code{.onLoad}.
+#' Global reference to ssw-py which will be initialized in `.onLoad`.
 #'
 #' @return ssw-py reference object
 #'

--- a/R/print.R
+++ b/R/print.R
@@ -1,8 +1,8 @@
 #' Print SSW alignment results
 #'
-#' @param x An object of class \code{ssw}.
+#' @param x An object of class `ssw`.
 #' @param start_idx Index to start printing from.
-#' @param ... Additional parameters for \code{\link{print}} (not used).
+#' @param ... Additional parameters for [print()] (not used).
 #'
 #' @method print ssw
 #'
@@ -13,12 +13,12 @@
 #' a
 
 print.ssw <- function (x, start_idx = 0L, ...) {
-  x$ssw$printResult(x$alignment, start_idx = as.integer(start_idx))
+  x$ssw$print_result(x$alignment, start_idx = as.integer(start_idx))
 }
 
 #' Format and pretty-print SSW forced alignment results without truncation
 #'
-#' @param x Forced alignment results. An object of class \code{ssw}.
+#' @param x Forced alignment results. An object of class `ssw`.
 #' @param print Pretty-print the results?
 #'
 #' @export formatter

--- a/man/align.Rd
+++ b/man/align.Rd
@@ -5,8 +5,8 @@
 \title{Align a read to the reference with optional index offsetting}
 \usage{
 align(
-  read = NULL,
-  reference = NULL,
+  read,
+  reference,
   gap_open = 3L,
   gap_extension = 1L,
   start_idx = 0L,

--- a/man/install_ssw_py.Rd
+++ b/man/install_ssw_py.Rd
@@ -11,18 +11,18 @@ install_ssw_py(
 )
 }
 \arguments{
-\item{...}{Other arguments passed to [reticulate::py_install()].}
+\item{...}{Other arguments passed to \code{\link[reticulate:py_install]{reticulate::py_install()}}.}
 
 \item{envname}{The name or full path of the environment in which
-ssw-py is installed. Default is `r-ssw-py`.}
+ssw-py is installed. Default is \code{r-ssw-py}.}
 
-\item{new_env}{Logical. If `TRUE`, the specified Python environment
+\item{new_env}{Logical. If \code{TRUE}, the specified Python environment
 will be deleted and recreated if it already exists.
-Defaults to `TRUE` only when using the default environment name.}
+Defaults to \code{TRUE} only when using the default environment name.}
 }
 \value{
-Invisibly returns `NULL`. Primarily used for its side effect
-  of installing the Python package in the specified environment.
+Invisibly returns \code{NULL}. Primarily used for its side effect
+of installing the Python package in the specified environment.
 }
 \description{
 Install ssw-py and its dependencies

--- a/man/is_installed_ssw_py.Rd
+++ b/man/is_installed_ssw_py.Rd
@@ -7,7 +7,7 @@
 is_installed_ssw_py()
 }
 \value{
-`TRUE` if installed, `FALSE` if not.
+\code{TRUE} if installed, \code{FALSE} if not.
 }
 \description{
 Is ssw-py installed?

--- a/man/print.ssw.Rd
+++ b/man/print.ssw.Rd
@@ -11,7 +11,7 @@
 
 \item{start_idx}{Index to start printing from.}
 
-\item{...}{Additional parameters for \code{\link{print}} (not used).}
+\item{...}{Additional parameters for \code{\link[=print]{print()}} (not used).}
 }
 \description{
 Print SSW alignment results

--- a/vignettes/ssw.Rmd
+++ b/vignettes/ssw.Rmd
@@ -47,25 +47,39 @@ Align the read against the reference sequence (`TTTTACGTCCCCC`) and print the re
 read |> align("TTTTACGTCCCCC")
 ```
 
-```
+```{text, echo = !run}
 CIGAR start index 4: 4M
-optimal_score: 8	sub-optimal_score: 0
+optimal_score: 8
+sub-optimal_score: 0
 target_begin: 4	target_end: 7
-query_begin: 0	query_end: 3
+query_begin: 0
+query_end: 3
 
 Target:        4    ACGT    7
                     ||||
 Query:         0    ACGT    3
-
-ACGT
 ```
 
 Get specific results, such as the alignment scores:
 
 ```{r}
 a <- read |> align("TTTTACGTCCCCC")
+```
+
+```{r}
 a$alignment$optimal_score
+```
+
+```{text, echo = !run}
+[1] 8
+```
+
+```{r}
 a$alignment$sub_optimal_score
+```
+
+```{text, echo = !run}
+[1] 0
 ```
 
 ## Deletion
@@ -74,17 +88,17 @@ a$alignment$sub_optimal_score
 read |> align("TTTTACAGTCCCCC")
 ```
 
-```
+```{text, echo = !run}
 CIGAR start index 4: 2M1D2M
-optimal_score: 5	sub-optimal_score: 0
+optimal_score: 5
+sub-optimal_score: 0
 target_begin: 4	target_end: 8
-query_begin: 0	query_end: 3
+query_begin: 0
+query_end: 3
 
 Target:        4    ACAGT    8
                     ||*||
 Query:         0    AC-GT    3
-
-ACGT
 ```
 
 ## Insertion with gap open
@@ -93,17 +107,17 @@ ACGT
 read |> align("TTTTACTCCCCC", gap_open = 3)
 ```
 
-```
+```{text, echo = !run}
 CIGAR start index 4: 2M
-optimal_score: 4	sub-optimal_score: 0
+optimal_score: 4
+sub-optimal_score: 0
 target_begin: 4	target_end: 5
-query_begin: 0	query_end: 1
+query_begin: 0
+query_end: 1
 
 Target:        4    AC    5
                     ||
 Query:         0    AC    1
-
-ACGT
 ```
 
 ## Insertion with no gap open penalty
@@ -112,17 +126,17 @@ ACGT
 read |> align("TTTTACTCCCCC", gap_open = 0)
 ```
 
-```
+```{text, echo = !run}
 CIGAR start index 4: 2M1I1M
-optimal_score: 6	sub-optimal_score: 0
+optimal_score: 6
+sub-optimal_score: 0
 target_begin: 4	target_end: 6
-query_begin: 0	query_end: 3
+query_begin: 0
+query_end: 3
 
 Target:        4    AC-T    6
                     ||*|
 Query:         0    ACGT    3
-
-ACGT
 ```
 
 ## Specify start index
@@ -132,17 +146,17 @@ a <- align("ACTG", "ACTCACTG", start_idx = 4)
 a
 ```
 
-```
+```{text, echo = !run}
 CIGAR start index 0: 4M
-optimal_score: 8	sub-optimal_score: 0
+optimal_score: 8
+sub-optimal_score: 0
 target_begin: 0	target_end: 3
-query_begin: 0	query_end: 3
+query_begin: 0
+query_end: 3
 
 Target:        0    ACTC    3
                     |||*
 Query:         0    ACTG    3
-
-ACTG
 ```
 
 Print the results from position 4:
@@ -151,17 +165,17 @@ Print the results from position 4:
 a |> print(start_idx = 4)
 ```
 
-```
+```{text, echo = !run}
 CIGAR start index 0: 4M
-optimal_score: 8	sub-optimal_score: 0
+optimal_score: 8
+sub-optimal_score: 0
 target_begin: 0	target_end: 3
-query_begin: 0	query_end: 3
+query_begin: 0
+query_end: 3
 
 Target:        0    ACTG    3
                     ||||
 Query:         0    ACTG    3
-
-ACTG
 ```
 
 ## Forced alignment
@@ -175,17 +189,17 @@ a
 
 The results are truncated:
 
-```
+```{text, echo = !run}
 CIGAR start index 4: 3M
-optimal_score: 6	sub-optimal_score: 0
+optimal_score: 6
+sub-optimal_score: 0
 target_begin: 4	target_end: 6
-query_begin: 1	query_end: 3
+query_begin: 1
+query_end: 3
 
 Target:        4    CTG    6
                     |||
 Query:         1    CTG    3
-
-ACTG
 ```
 
 Use `formatter()` to avoid the truncation:
@@ -195,13 +209,21 @@ b <- a |> formatter()
 b
 ```
 
+```{text, echo = !run}
+[[1]]
+[1] "TTTTCTGCCCCCACG"
+
+[[2]]
+[1] "   ACTG"
+```
+
 Or pretty-print the formatted results directly:
 
 ```{r}
 a |> formatter(print = TRUE)
 ```
 
-```
+```{text, echo = !run}
 TTTTCTGCCCCCACG
    ACTG
 ```


### PR DESCRIPTION
ssw-py 1.0.0 has some major API name changes. For example, `SSW` is now `AlignmentMgr`; most functions are named using snake case instead of camel case.

This PR updates the wrapper to use the new API and declares the ssw-py version requirement in `DESCRIPTION`.

Also runs `usethis::use_roxygen_md()` to enable Markdown for roxygen2.