### PR TITLE
Replace knitr code chunks with Markdown code blocks in vignette

### DIFF
--- a/vignettes/ssw.Rmd
+++ b/vignettes/ssw.Rmd
@@ -28,13 +28,13 @@ a fast implementation of the Smith-Waterman algorithm for sequence alignment
 using SIMD, described in @zhao2013ssw. The package is currently built on
 [ssw-py](https://pypi.org/project/ssw-py/).
 
-```{r}
+```r
 library("ssw")
 ```
 
 A short read sequence:
 
-```{r}
+```r
 read <- "ACGT"
 ```
 
@@ -42,11 +42,11 @@ read <- "ACGT"
 
 Align the read against the reference sequence (`TTTTACGTCCCCC`) and print the results:
 
-```{r}
+```r
 read |> align("TTTTACGTCCCCC")
 ```
 
-```{text, echo = !run}
+```text
 CIGAR start index 4: 4M
 optimal_score: 8
 sub-optimal_score: 0
@@ -61,33 +61,33 @@ Query:         0    ACGT    3
 
 Get specific results, such as the alignment scores:
 
-```{r}
+```r
 a <- read |> align("TTTTACGTCCCCC")
 ```
 
-```{r}
+```r
 a$alignment$optimal_score
 ```
 
-```{text, echo = !run}
+```text
 [1] 8
 ```
 
-```{r}
+```r
 a$alignment$sub_optimal_score
 ```
 
-```{text, echo = !run}
+```text
 [1] 0
 ```
 
 ## Deletion
 
-```{r}
+```r
 read |> align("TTTTACAGTCCCCC")
 ```
 
-```{text, echo = !run}
+```text
 CIGAR start index 4: 2M1D2M
 optimal_score: 5
 sub-optimal_score: 0
@@ -102,11 +102,11 @@ Query:         0    AC-GT    3
 
 ## Insertion with gap open
 
-```{r}
+```r
 read |> align("TTTTACTCCCCC", gap_open = 3)
 ```
 
-```{text, echo = !run}
+```text
 CIGAR start index 4: 2M
 optimal_score: 4
 sub-optimal_score: 0
@@ -121,11 +121,11 @@ Query:         0    AC    1
 
 ## Insertion with no gap open penalty
 
-```{r}
+```r
 read |> align("TTTTACTCCCCC", gap_open = 0)
 ```
 
-```{text, echo = !run}
+```text
 CIGAR start index 4: 2M1I1M
 optimal_score: 6
 sub-optimal_score: 0
@@ -140,12 +140,12 @@ Query:         0    ACGT    3
 
 ## Specify start index
 
-```{r}
+```r
 a <- align("ACTG", "ACTCACTG", start_idx = 4)
 a
 ```
 
-```{text, echo = !run}
+```text
 CIGAR start index 0: 4M
 optimal_score: 8
 sub-optimal_score: 0
@@ -160,11 +160,11 @@ Query:         0    ACTG    3
 
 Print the results from position 4:
 
-```{r}
+```r
 a |> print(start_idx = 4)
 ```
 
-```{text, echo = !run}
+```text
 CIGAR start index 0: 4M
 optimal_score: 8
 sub-optimal_score: 0
@@ -181,14 +181,14 @@ Query:         0    ACTG    3
 
 Enforce no gaps by increasing the penalty:
 
-```{r}
+```r
 a <- force_align("ACTG", "TTTTCTGCCCCCACG")
 a
 ```
 
 The results are truncated:
 
-```{text, echo = !run}
+```text
 CIGAR start index 4: 3M
 optimal_score: 6
 sub-optimal_score: 0
@@ -203,12 +203,12 @@ Query:         1    CTG    3
 
 Use `formatter()` to avoid the truncation:
 
-```{r}
+```r
 b <- a |> formatter()
 b
 ```
 
-```{text, echo = !run}
+```text
 [[1]]
 [1] "TTTTCTGCCCCCACG"
 
@@ -218,11 +218,11 @@ b
 
 Or pretty-print the formatted results directly:
 
-```{r}
+```r
 a |> formatter(print = TRUE)
 ```
 
-```{text, echo = !run}
+```text
 TTTTCTGCCCCCACG
    ACTG
 ```


### PR DESCRIPTION
Fixes #20 

Now, running

```bash
_R_CHECK_VIGNETTES_SKIP_RUN_MAYBE_=false R CMD check ssw_0.2.0.tar.gz
```

can pass without the error.